### PR TITLE
Userモデルの作成

### DIFF
--- a/backend/.rubocop.yml
+++ b/backend/.rubocop.yml
@@ -69,3 +69,8 @@ Metrics/MethodLength:
   Max: 20
   Exclude:
     - "db/migrate/*.rb"
+
+# ブロックの行数
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*'

--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -14,7 +14,7 @@ gem 'puma', '~> 5.0'
 # Use Redis adapter to run Action Cable in production
 # gem 'redis', '~> 4.0'
 # Use Active Model has_secure_password
-# gem 'bcrypt', '~> 3.1.7'
+gem 'bcrypt', '~> 3.1.7'
 
 # Use Active Storage variant
 # gem 'image_processing', '~> 1.2'
@@ -25,9 +25,15 @@ gem 'bootsnap', '>= 1.4.4', require: false
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
 gem 'rack-cors'
 
+# バリデーションメッセージの日本語化
+gem 'rails-i18n'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: %i[mri mingw x64_mingw]
+
+  gem 'factory_bot_rails'
+  gem 'rspec-rails'
 end
 
 group :development do
@@ -36,9 +42,6 @@ group :development do
   gem 'spring'
 
   gem 'dotenv-rails'
-
-  gem 'factory_bot_rails'
-  gem 'rspec-rails'
 
   gem 'rubocop', require: false
   gem 'rubocop-performance', require: false

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -61,6 +61,7 @@ GEM
       tzinfo (~> 2.0)
       zeitwerk (~> 2.3)
     ast (2.4.2)
+    bcrypt (3.1.18)
     bootsnap (1.15.0)
       msgpack (~> 1.2)
     builder (3.2.4)
@@ -145,6 +146,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.4.4)
       loofah (~> 2.19, >= 2.19.1)
+    rails-i18n (7.0.6)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 8)
     railties (6.1.7)
       actionpack (= 6.1.7)
       activesupport (= 6.1.7)
@@ -219,6 +223,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  bcrypt (~> 3.1.7)
   bootsnap (>= 1.4.4)
   byebug
   dotenv-rails
@@ -228,6 +233,7 @@ DEPENDENCIES
   puma (~> 5.0)
   rack-cors
   rails (~> 6.1.5)
+  rails-i18n
   rspec-rails
   rubocop
   rubocop-performance

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -1,0 +1,10 @@
+class User < ApplicationRecord
+  validates :user_name, presence: true, length: { maximum: 15 }
+
+  before_save { self.email = email.downcase }
+  VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d-]+(\.[a-z\d-]+)*\.[a-z]+\z/i
+  validates :email, presence: true, format: { with: VALID_EMAIL_REGEX }, uniqueness: { case_sensitive: false }
+
+  has_secure_password
+  validates :password, presence: true, length: { minimum: 6, maximum: 10 }, allow_nil: true
+end

--- a/backend/config/application.rb
+++ b/backend/config/application.rb
@@ -36,5 +36,11 @@ module ReviewApp
     # Middleware like session, flash, cookies can be added back manually.
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
+
+    # デフォルトのロケールを:en以外に変更する
+    config.i18n.default_locale = :ja
+
+    # I18nライブラリに訳文の探索場所を指示する
+    config.i18n.load_path += Dir[Rails.root.join('config/locales/**/*.yml').to_s]
   end
 end

--- a/backend/config/locales/ja.yml
+++ b/backend/config/locales/ja.yml
@@ -1,0 +1,7 @@
+ja:
+  activerecord:
+    attributes:
+      user:
+        user_name: 名前
+        email: メールアドレス
+        password: パスワード

--- a/backend/db/migrate/20221218054040_create_users.rb
+++ b/backend/db/migrate/20221218054040_create_users.rb
@@ -1,0 +1,10 @@
+class CreateUsers < ActiveRecord::Migration[6.1]
+  def change
+    create_table :users do |t|
+      t.string :user_name
+      t.string :email
+
+      t.timestamps
+    end
+  end
+end

--- a/backend/db/migrate/20221218062106_add_index_to_users_email.rb
+++ b/backend/db/migrate/20221218062106_add_index_to_users_email.rb
@@ -1,0 +1,5 @@
+class AddIndexToUsersEmail < ActiveRecord::Migration[6.1]
+  def change
+    add_index :users, :email, unique: true
+  end
+end

--- a/backend/db/migrate/20221218064425_add_password_digest_to_users.rb
+++ b/backend/db/migrate/20221218064425_add_password_digest_to_users.rb
@@ -1,0 +1,5 @@
+class AddPasswordDigestToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :password_digest, :string
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,6 +10,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 0) do
+ActiveRecord::Schema.define(version: 2022_12_18_064425) do
+
+  create_table "users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "user_name"
+    t.string "email"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.string "password_digest"
+    t.index ["email"], name: "index_users_on_email", unique: true
+  end
 
 end

--- a/backend/spec/factories/users.rb
+++ b/backend/spec/factories/users.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :user do
+    user_name { 'MyString' }
+    email { 'MyString' }
+  end
+end

--- a/backend/spec/models/user_spec.rb
+++ b/backend/spec/models/user_spec.rb
@@ -1,0 +1,87 @@
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+  describe 'ユーザーモデルのバリデーションチェック' do
+    context 'データが有効な場合' do
+      it '名前とメールアドレスが存在する' do
+        user = create(:user, user_name: '山田太郎', email: 'taro@example.com', password: 'password', password_confirmation: 'password')
+        expect(user).to be_valid
+      end
+
+      it '名前が15文字以内である' do
+        user = create(:user, user_name: 'あ' * 15, email: 'taro@example.com', password: 'password', password_confirmation: 'password')
+        expect(user).to be_valid
+      end
+
+      it 'パスワードが6文字以上である' do
+        user = create(:user, user_name: '山田太郎', email: 'taro@example.com', password: 'a' * 6, password_confirmation: 'a' * 6)
+        expect(user).to be_valid
+      end
+
+      it 'パスワードが10文字以内である' do
+        user = create(:user, user_name: '山田太郎', email: 'taro@example.com', password: 'a' * 10, password_confirmation: 'a' * 10)
+        expect(user).to be_valid
+      end
+    end
+
+    context 'データが無効な場合' do
+      it '名前が存在しない' do
+        user = build(:user, user_name: nil, email: 'taro@example.com', password: 'password', password_confirmation: 'password')
+        user.valid?
+        expect(user.errors[:user_name]).to include('を入力してください')
+      end
+
+      it '名前が16文字以上である' do
+        user = build(:user, user_name: 'あ' * 16, email: 'taro@example.com', password: 'password', password_confirmation: 'password')
+        user.valid?
+        expect(user.errors[:user_name]).to include('は15文字以内で入力してください')
+      end
+
+      it 'メールアドレスが存在しない' do
+        user = build(:user, user_name: '山田太郎', email: nil, password: 'password', password_confirmation: 'password')
+        user.valid?
+        expect(user.errors[:email]).to include('を入力してください')
+      end
+
+      it 'メールアドレスが正規表現に沿っていない' do
+        user1 = build(:user, user_name: '山田太郎', email: 'taro@gmail,com', password: 'password', password_confirmation: 'password')
+        user2 = build(:user, user_name: '山田太郎', email: 'taro_at_foo.org', password: 'password', password_confirmation: 'password')
+        user3 = build(:user, user_name: '山田太郎', email: 'taro.name@example.', password: 'password', password_confirmation: 'password')
+        user4 = build(:user, user_name: '山田太郎', email: 'taro@bar_baz.com', password: 'password', password_confirmation: 'password')
+        user5 = build(:user, user_name: '山田太郎', email: 'taro@bar+baz.com', password: 'password', password_confirmation: 'password')
+
+        expect(user1).not_to be_valid
+        expect(user2).not_to be_valid
+        expect(user3).not_to be_valid
+        expect(user4).not_to be_valid
+        expect(user5).not_to be_valid
+      end
+
+      it 'メールアドレスが重複している' do
+        user = create(:user, user_name: '山田太郎', email: 'taro@example.com', password: 'password', password_confirmation: 'password')
+        expect(user).to be_valid
+        another_user = build(:user, user_name: '鈴木太郎', email: 'taro@example.com', password: 'password', password_confirmation: 'password')
+        another_user.valid?
+        expect(another_user.errors[:email]).to include('はすでに存在します')
+      end
+
+      it 'パスワードが5文字以内である' do
+        user = build(:user, user_name: '山田太郎', email: 'taro@example.com', password: 'a' * 5, password_confirmation: 'a' * 5)
+        user.valid?
+        expect(user.errors[:password]).to include('は6文字以上で入力してください')
+      end
+
+      it 'パスワードが11文字以上である' do
+        user = build(:user, user_name: '山田太郎', email: 'taro@example.com', password: 'a' * 11, password_confirmation: 'a' * 11)
+        user.valid?
+        expect(user.errors[:password]).to include('は10文字以内で入力してください')
+      end
+
+      it 'パスワードとパスワード確認が不一致である' do
+        user = build(:user, user_name: '山田太郎', email: 'taro@example.com', password: 'password', password_confirmation: 'hassworr')
+        user.valid?
+        expect(user.errors[:password_confirmation]).to include('とパスワードの入力が一致しません')
+      end
+    end
+  end
+end

--- a/backend/spec/rails_helper.rb
+++ b/backend/spec/rails_helper.rb
@@ -60,4 +60,6 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  config.include FactoryBot::Syntax::Methods
 end


### PR DESCRIPTION
# 実装内容

## ①Userモデルの作成
追加したカラムは以下の通り。
- user_name:string
- email:string
- password_digest:string（gem 'bycrypt'をインストール）

Ruby on Rails チュートリアルの[第6章](https://railstutorial.jp/chapters/modeling_users?version=6.0#sec-adding_a_secure_password)を参照

## ②Userモデルのテストコードを記述
テスト項目は以下の通り
- 名前・メールアドレスの存在チェック
- 名前・パスワードの文字数チェック
- メールアドレスの重複チェック
- メールアドレスの正規表現チェック
- パスワードとパスワード確認の一致チェック

## ②エラーメッセージの日本語化
gem 'rails-i18n'をインストール
参照サイト：[【Rails】validatesのエラーメッセージを日本語化する方法](https://medium-company.com/rails-validates-%E3%82%A8%E3%83%A9%E3%83%BC%E3%83%A1%E3%83%83%E3%82%BB%E3%83%BC%E3%82%B8-%E6%97%A5%E6%9C%AC%E8%AA%9E%E5%8C%96/)
