### PR TITLE
新規登録APIを実装

### DIFF
--- a/backend/.rubocop.yml
+++ b/backend/.rubocop.yml
@@ -74,3 +74,8 @@ Metrics/MethodLength:
 Metrics/BlockLength:
   Exclude:
     - 'spec/**/*'
+
+# Rubocopはコンパクト記法ではなくネスト記法を推奨
+Style/ClassAndModuleChildren:
+  Exclude:
+    - 'app/controllers/api/v1/*'

--- a/backend/app/controllers/api/v1/users_controller.rb
+++ b/backend/app/controllers/api/v1/users_controller.rb
@@ -7,12 +7,11 @@ class Api::V1::UsersController < ApplicationController
     else
       render json: { status: 500 }
     end
-
   end
 
   private
 
-    def user_params
-      params.permit(:user_name, :email, :password, :password_confirmation)
-    end
+  def user_params
+    params.permit(:user_name, :email, :password, :password_confirmation)
+  end
 end

--- a/backend/app/controllers/api/v1/users_controller.rb
+++ b/backend/app/controllers/api/v1/users_controller.rb
@@ -1,0 +1,18 @@
+class Api::V1::UsersController < ApplicationController
+  def create
+    @user = User.new(user_params)
+    if @user.save
+      login(@user)
+      render json: { status: :created, user: @user }
+    else
+      render json: { status: 500 }
+    end
+
+  end
+
+  private
+
+    def user_params
+      params.permit(:user_name, :email, :password, :password_confirmation)
+    end
+end

--- a/backend/app/controllers/application_controller.rb
+++ b/backend/app/controllers/application_controller.rb
@@ -1,2 +1,9 @@
 class ApplicationController < ActionController::API
+  def login(user)
+    session[:user_id] = user.id
+  end
+
+  def current_user
+    @current_user = User.find(sesion[:user_id]) if session[:user_id]
+  end
 end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -1,3 +1,7 @@
 Rails.application.routes.draw do
-  # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
+  namespace :api do
+    namespace :v1 do
+      resources :users, only: [:create]
+    end
+  end
 end

--- a/backend/spec/requests/api/v1/users_spec.rb
+++ b/backend/spec/requests/api/v1/users_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe "Api::V1::Users", type: :request do
+  describe "ユーザーを新規登録する" do
+    it "成功する場合" do
+      user_params = { user_name: '山田太郎', email: 'taro@example.com', password: 'password', password_confirmation: 'password' }
+
+      # データの作成を確認
+      expect { post '/api/v1/users', params: user_params }.to change(User, :count).by(+1)
+      json = JSON.parse(response.body)
+
+      # リクエスト成功を確認
+      expect(response.status).to eq(200)
+
+      # 登録したユーザーのデータを返すことを確認
+      expect(json['user']['user_name']).to eq('山田太郎')
+      expect(json['user']['email']).to eq('taro@example.com')
+    end
+  end
+
+end

--- a/backend/spec/requests/api/v1/users_spec.rb
+++ b/backend/spec/requests/api/v1/users_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
-RSpec.describe "Api::V1::Users", type: :request do
-  describe "ユーザーを新規登録する" do
-    it "成功する場合" do
+RSpec.describe 'Api::V1::Users', type: :request do
+  describe 'ユーザーを新規登録する' do
+    it '成功する場合' do
       user_params = { user_name: '山田太郎', email: 'taro@example.com', password: 'password', password_confirmation: 'password' }
 
       # データの作成を確認
@@ -17,5 +17,4 @@ RSpec.describe "Api::V1::Users", type: :request do
       expect(json['user']['email']).to eq('taro@example.com')
     end
   end
-
 end


### PR DESCRIPTION
# 実装内容
- 新規登録API（/api/v1/users#create）の作成
- 新規登録APIのテストコードの作成
- Postmanでも挙動を確認済。